### PR TITLE
Fix keys path for MacOS, and pull fs ops in their own internal package

### DIFF
--- a/internal/clifs/clifs.go
+++ b/internal/clifs/clifs.go
@@ -1,0 +1,76 @@
+// Package to encapsulate CLI filesystem operations
+package clifs
+
+import (
+	"fmt"
+	"io/fs"
+	"os"
+	"strings"
+
+	"github.com/pkg/errors"
+	"github.com/tkhq/tkcli/internal/apikey"
+)
+
+// Given a user-specified directory, return the path.
+// The logic is in the case where users do not specify a folder.
+// If the folder isn't specified, we default to $XDG_CONFIG_HOME/.config/turnkey/keys.
+// If this env var isn't set, we default to $HOME/.config/turnkey/keys
+// If $HOME isn't set, this function returns an error.
+func GetKeyDirPath(userSpecifiedPath string) (string, error) {
+	if userSpecifiedPath == "" {
+		var configHome string
+		if os.Getenv("XDG_CONFIG_HOME") != "" {
+			configHome = os.Getenv("XDG_CONFIG_HOME")
+		} else {
+			homeDir, err := os.UserHomeDir()
+			if err != nil {
+				return "", errors.Wrap(err, "error while reading user home directory")
+			}
+			configHome = homeDir + "/.config"
+		}
+		return configHome + "/turnkey/keys", nil
+	} else {
+		if _, err := os.Stat(userSpecifiedPath); !os.IsNotExist(err) {
+			return userSpecifiedPath, nil
+		} else {
+			return "", errors.Errorf("Cannot put key files in %s: %v", userSpecifiedPath, err)
+		}
+	}
+}
+
+func CreateFile(path string, content string, mode fs.FileMode) error {
+	return os.WriteFile(path, []byte(content), mode)
+}
+
+func GetFileContent(path string) (string, error) {
+	bytes, err := os.ReadFile(path)
+	if err != nil {
+		return "", err
+	}
+	return string(bytes), nil
+}
+
+func GetApiKey(key string) (*apikey.ApiKey, error) {
+	var keyPath string
+	if !strings.Contains(key, "/") && !strings.Contains(key, ".") {
+		keysDirectory, err := GetKeyDirPath("")
+		if err != nil {
+			return nil, errors.Wrap(err, "unable to get keys directory path")
+		}
+		keyPath = fmt.Sprintf("%s/%s.private", keysDirectory, key)
+	} else {
+		// We have a full file path. Try loading it directly
+		keyPath = key
+	}
+
+	bytes, err := GetFileContent(keyPath)
+	if err != nil {
+		return nil, errors.Wrap(err, "unable to load private key:")
+	}
+
+	apiKey, err := apikey.FromTkPrivateKey(string(bytes))
+	if err != nil {
+		return nil, errors.Wrap(err, "could recover API key from private key file content:")
+	}
+	return apiKey, nil
+}

--- a/internal/clifs/clifs_test.go
+++ b/internal/clifs/clifs_test.go
@@ -1,0 +1,66 @@
+package clifs_test
+
+import (
+	"io/ioutil"
+	"os"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/tkhq/tkcli/internal/clifs"
+)
+
+// MacOSX has $HOME set by default
+func TestGetKeyDirPathMacOSX(t *testing.T) {
+	os.Setenv("HOME", "/home/dir")
+	defer os.Unsetenv("HOME")
+
+	// Need to unset this explicitly: the test runner has this set by default!
+	originalValue := os.Getenv("XDG_CONFIG_HOME")
+	os.Unsetenv("XDG_CONFIG_HOME")
+	defer os.Setenv("XDG_CONFIG_HOME", originalValue)
+
+	dir, err := clifs.GetKeyDirPath("")
+	assert.Nil(t, err)
+	assert.Equal(t, dir, "/home/dir/.config/turnkey/keys")
+}
+
+// On UNIX, we expect XDG_CONFIG_HOME to be set
+// If it's not set, we're back to a MacOSX-like system
+func TestGetKeyDirPathUnix(t *testing.T) {
+	os.Setenv("XDG_CONFIG_HOME", "/special/dir")
+	defer os.Unsetenv("XDG_CONFIG_HOME")
+
+	os.Setenv("HOME", "/home/dir")
+	defer os.Unsetenv("HOME")
+
+	dir, err := clifs.GetKeyDirPath("")
+	assert.Nil(t, err)
+	assert.Equal(t, dir, "/special/dir/turnkey/keys")
+}
+
+// In the case where we don't have a $HOME defined, bail!
+func TestGetKeyDirPathDysfunctionalOS(t *testing.T) {
+	originalValue := os.Getenv("HOME")
+	os.Unsetenv("HOME")
+	defer os.Setenv("HOME", originalValue)
+
+	dir, err := clifs.GetKeyDirPath("")
+	assert.Equal(t, dir, "")
+	assert.Equal(t, "error while reading user home directory: $HOME is not defined", err.Error())
+}
+
+// If calling with a path, we should get this back if the path exists
+// If not we should get an error
+func TestGetKeyDirPathOverride(t *testing.T) {
+	tmpDir, err := ioutil.TempDir("/tmp", "keys")
+	defer os.RemoveAll(tmpDir)
+	assert.Nil(t, err)
+
+	dir, err := clifs.GetKeyDirPath("/does/not/exist")
+	assert.Equal(t, "Cannot put key files in /does/not/exist: stat /does/not/exist: no such file or directory", err.Error())
+	assert.Equal(t, "", dir)
+
+	dir, err = clifs.GetKeyDirPath(tmpDir)
+	assert.Nil(t, err)
+	assert.Equal(t, tmpDir, dir)
+}


### PR DESCRIPTION
Currently the CLI uses `UserConfigDir`. Unfortunately, this means keys are in `/Library/Application Support` ([code link](https://cs.opensource.google/go/go/+/refs/tags/go1.19.4:src/os/file.go;l=457)). Not ideal. I think most people expect keys to be put somewhere within their home directory.

This branch fixes this and creates a new internal package, `clifs`, to contain all fs operations for tkcli. That way we shorten `main.go` and we get an interface to test against.