### PR TITLE
Print public key after creation

### DIFF
--- a/main.go
+++ b/main.go
@@ -78,6 +78,7 @@ func main() {
 							log.Fatalf("Unable to serialize output to JSON: %v", err)
 						}
 						fmt.Println(string(jsonBytes))
+						fmt.Printf("\nYour public key for Turnkey is:\n%s\n", apiKey.TkPublicKey)
 					}
 
 					return nil

--- a/main.go
+++ b/main.go
@@ -71,6 +71,7 @@ func main() {
 						clifs.CreateFile(privateKeyFile, apiKey.TkPrivateKey, 0700)
 
 						jsonBytes, err := json.MarshalIndent(map[string]interface{}{
+							"publicKey":      apiKey.TkPublicKey,
 							"publicKeyFile":  publicKeyFile,
 							"privateKeyFile": privateKeyFile,
 						}, "", "    ")
@@ -78,7 +79,6 @@ func main() {
 							log.Fatalf("Unable to serialize output to JSON: %v", err)
 						}
 						fmt.Println(string(jsonBytes))
-						fmt.Printf("\nYour public key for Turnkey is:\n%s\n", apiKey.TkPublicKey)
 					}
 
 					return nil

--- a/main_test.go
+++ b/main_test.go
@@ -56,9 +56,13 @@ func TestKeygenInTmpFolder(t *testing.T) {
 	assert.FileExists(t, tmpDir+"/mykey.public")
 	assert.FileExists(t, tmpDir+"/mykey.private")
 
+	publicKeyData, err := os.ReadFile(tmpDir + "/mykey.public")
+	assert.Nil(t, err)
+
 	var parsedOut map[string]string
 	err = json.Unmarshal([]byte(out), &parsedOut)
 	assert.Nil(t, err)
+	assert.Equal(t, parsedOut["publicKey"], string(publicKeyData))
 	assert.Equal(t, parsedOut["publicKeyFile"], tmpDir+"/mykey.public")
 	assert.Equal(t, parsedOut["privateKeyFile"], tmpDir+"/mykey.private")
 }


### PR DESCRIPTION
```
$ ./build/turnkey gen --name 1234
{
    "privateKeyFile": "/Users/<user>/.config/turnkey/keys/1234.private",
    "publicKey": "0364ecc3534be3b5bfb8b5ecd3a156faf717959ce12137a41a8ea00f184b45f428",
    "publicKeyFile": "/Users/<user>/.config/turnkey/keys/1234.public"
}
```