### PR TITLE
bug; fixes buildfile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,16 +1,16 @@
 .PHONY: all
-all: build/turnkey
+all: build
 
 .PHONY: local-release
 local-release:
 	goreleaser release --snapshot --rm-dist
 
 .PHONY: test
-test: build/turnkey
+test: build
 	go test ./...
 
-.PHONY: build/turnkey
-build/turnkey: main.go internal/
+.PHONY: build
+build:
 	go build -o build/turnkey main.go
 
 .PHONY: clean

--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,5 @@
 .PHONY: all
-all: build
+all: build/turnkey
 
 .PHONY: local-release
 local-release:

--- a/Makefile
+++ b/Makefile
@@ -9,6 +9,7 @@ local-release:
 test: build/turnkey
 	go test ./...
 
+.PHONY: build/turnkey
 build/turnkey: main.go internal/
 	go build -o build/turnkey main.go
 


### PR DESCRIPTION
Fixes the `all` target in the Makefile by aliasing it to the `build/turnkey` target.

Previously, this target would fail as no such target exists