### PR TITLE
Fix go.mod path

### DIFF
--- a/src/go.mod
+++ b/src/go.mod
@@ -1,4 +1,4 @@
-module github.com/tkhq/tkcli
+module github.com/tkhq/tkcli/src
 
 go 1.19
 

--- a/src/internal/apikey/apikey_test.go
+++ b/src/internal/apikey/apikey_test.go
@@ -10,7 +10,7 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/assert"
-	"github.com/tkhq/tkcli/internal/apikey"
+	"github.com/tkhq/tkcli/src/internal/apikey"
 )
 
 func Test_FromTkPrivateKey(t *testing.T) {

--- a/src/internal/clifs/clifs.go
+++ b/src/internal/clifs/clifs.go
@@ -8,7 +8,7 @@ import (
 	"strings"
 
 	"github.com/pkg/errors"
-	"github.com/tkhq/tkcli/internal/apikey"
+	"github.com/tkhq/tkcli/src/internal/apikey"
 )
 
 // Given a user-specified directory, return the path.

--- a/src/internal/clifs/clifs_test.go
+++ b/src/internal/clifs/clifs_test.go
@@ -6,7 +6,7 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/assert"
-	"github.com/tkhq/tkcli/internal/clifs"
+	"github.com/tkhq/tkcli/src/internal/clifs"
 )
 
 // MacOSX has $HOME set by default

--- a/src/internal/display/display_test.go
+++ b/src/internal/display/display_test.go
@@ -7,7 +7,7 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/assert"
-	"github.com/tkhq/tkcli/internal/display"
+	"github.com/tkhq/tkcli/src/internal/display"
 )
 
 func TestDisplayResponse(t *testing.T) {

--- a/src/main.go
+++ b/src/main.go
@@ -10,10 +10,10 @@ import (
 	"strings"
 
 	"github.com/pkg/errors"
-	"github.com/tkhq/tkcli/internal/apikey"
-	"github.com/tkhq/tkcli/internal/clifs"
-	"github.com/tkhq/tkcli/internal/display"
-	"github.com/tkhq/tkcli/internal/flags"
+	"github.com/tkhq/tkcli/src/internal/apikey"
+	"github.com/tkhq/tkcli/src/internal/clifs"
+	"github.com/tkhq/tkcli/src/internal/display"
+	"github.com/tkhq/tkcli/src/internal/flags"
 
 	"github.com/urfave/cli/v2"
 )

--- a/src/main_test.go
+++ b/src/main_test.go
@@ -12,7 +12,7 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/assert"
-	"github.com/tkhq/tkcli/internal/apikey"
+	"github.com/tkhq/tkcli/src/internal/apikey"
 )
 
 const TURNKEY_BINARY_NAME = "turnkey.linux-x86_64"


### PR DESCRIPTION
After #9 was merged and v0.3.4 released we noticed failures to install the latest version of the go package:
```sh
$ go install github.com/tkhq/tkcli@latest
go: downloading github.com/tkhq/tkcli v0.3.4
go: github.com/tkhq/tkcli@latest: module github.com/tkhq/tkcli@latest found (v0.3.4), but does not contain package github.com/tkhq/tkcli
```
Specifying the folder doesn't work either:
```sh
$ go install -v github.com/tkhq/tkcli/src@latest
go: github.com/tkhq/tkcli/src@latest: github.com/tkhq/tkcli/src@v0.0.0-20230413013040-6938a0c3d432: parsing go.mod:
	module declares its path as: github.com/tkhq/tkcli
	        but was required as: github.com/tkhq/tkcli/src
```

This mini-diff should fix the issue!


I tagged/released this as `v0.3.5-beta2` and `src/v0.3.5-beta2` (yes, [prefixed tags](https://github.com/golang/go/issues/34055#issuecomment-777463760)...😮‍💨). And it works as far as I can tell:
```sh
go install github.com/tkhq/tkcli/src@v0.3.5-beta2
go: downloading github.com/tkhq/tkcli v0.3.5-beta2
go: downloading github.com/tkhq/tkcli/src v0.3.5-beta2
```