### PR TITLE
Toolchain submodule update

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -40,6 +40,11 @@ test: $(OUT_DIR)/turnkey.linux-x86_64
 		env -C $(SRC_DIR) go test -v ./... \
 	')
 
+.PHONY: install
+install: default
+	mkdir -p ~/.local/bin
+	cp $(OUT_DIR)/turnkey.$(HOST_OS)-$(HOST_ARCH) ~/.local/bin/turnkey
+
 # Clean repo back to initial clone state
 .PHONY: clean
 clean: toolchain-clean

--- a/README.md
+++ b/README.md
@@ -34,7 +34,8 @@ all the time.
 ```sh
 git clone https://github.com/thkq/tkcli
 cd tkcli
-# Copy artifacts from `dist/` to a folder on your $PATH
+# This installs in  ~/.local/bin; make sure this is in your $PATH!
+make install
 ```
 
 #### Brew

--- a/README.md
+++ b/README.md
@@ -31,15 +31,15 @@ all the time.
 
 #### Git
 
-```
+```sh
 git clone https://github.com/thkq/tkcli
 cd tkcli
-make install
+# Copy artifacts from `dist/` to a folder on your $PATH
 ```
 
 #### Brew
 
-```
+```sh
 brew tap tkhq/tkcli
 brew install turnkey
 ```


### PR DESCRIPTION
This branch updates the toolchain submodule to make `make dist` work correctly. I got the following error when running locally from a fresh directory:
```sh
$ make dist
rm -rf dist/*
/Library/Developer/CommandLineTools/usr/bin/make toolchain-clean default
chmod -R u+w cache
chmod: cache: No such file or directory
make[1]: *** [toolchain-clean] Error 1
make: *** [dist] Error 2
```

I verified that the error is gone after the submodule bump. This is because toolchain is now checking for the existence of the cache dir before deleting it: https://codeberg.org/distrust/toolchain/src/commit/4eff8b258b1e9bc64f3d831ae160ac9256bfdd79/Makefile#L90-L93