### PR TITLE
Fix output for JSON-encoded responses

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -14,7 +14,7 @@
 # Apple folder files
 .DS_Store
 
-# Dist/build folder
+# Local build folder
 build/
 
 # Vscode-related configs

--- a/Makefile
+++ b/Makefile
@@ -10,6 +10,8 @@ ifneq ("$(wildcard $(ROOT)/src/toolchain)","")
 	clone := $(shell git submodule update --init --recursive)
 endif
 
+LOCAL_BUILD_DIR := 'build'
+
 .DEFAULT_GOAL :=
 .PHONY: default
 default: \
@@ -49,6 +51,7 @@ install: default
 .PHONY: clean
 clean: toolchain-clean
 	git clean -dfx $(SRC_DIR)
+	rm -rf $(LOCAL_BUILD_DIR)
 
 $(KEY_DIR)/%.asc:
 	$(call fetch_pgp_key,$(basename $(notdir $@)))
@@ -83,3 +86,9 @@ $(OUT_DIR)/turnkey.%:
 			-trimpath \
 			-o /home/build/$@ . \
 	')
+
+.PHONY: build-local
+build-local:
+	pushd $(shell git rev-parse --show-toplevel)/src; \
+	go build -o ../$(LOCAL_BUILD_DIR)/turnkey; \
+	popd;

--- a/README.md
+++ b/README.md
@@ -188,6 +188,14 @@ make
 make out/turnkey.linux-amd64
 ```
 
+### Local build (for development only)
+
+The following will drop a binary in `build/turnkey`:
+
+```
+make local-build
+```
+
 ## Release
 
 To release a new version of the CLI:


### PR DESCRIPTION
Fixes #22, and introduces a new `local-build` target for local development.

Here's the result:
```
./build/turnkey request --host coordinator-beta.turnkey.io --path /public/v1/query/whoami --body '{"organizationId": "3b05fe0d-2122-4a92-9d6d-ed5db20deab6"}' -k test -o yaml
organizationId: 3b05fe0d-2122-4a92-9d6d-ed5db20deab6
organizationName: Release 2023-04-20
userId: c5dbb343-2b6c-43cb-9080-d4d58af7b1fb
username: Root user
```

```
./build/turnkey request --host coordinator-beta.turnkey.io --path /public/v1/query/whoami --body '{"organizationId": "3b05fe0d-2122-4a92-9d6d-ed5db20deab6"}' -k test
{
   "organizationId": "3b05fe0d-2122-4a92-9d6d-ed5db20deab6",
   "organizationName": "Release 2023-04-20",
   "userId": "c5dbb343-2b6c-43cb-9080-d4d58af7b1fb",
   "username": "Root user"
}