### PR TITLE
[bug] fix request keys-directory regression

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -39,6 +39,7 @@
           ${pkgs.gofumpt}/bin/gofumpt -w *.go ./cmd/*
           ${gci}/bin/gci write --skip-generated -s standard -s default -s "Prefix(github.com/tkhq)" .
           ${pkgs.golangci-lint}/bin/golangci-lint run ./...
+          ${pkgs.go}/bin/go test -v ./...
         '';
       in
       {

--- a/src/cmd/ethereum.go
+++ b/src/cmd/ethereum.go
@@ -54,7 +54,7 @@ var ethTxCmd = &cobra.Command{
 
 		params := private_keys.NewPublicAPIServiceSignTransactionParams().WithBody(
 			&models.V1SignTransactionRequest{
-				OrganizationID: &privateKeysOrgID,
+				OrganizationID: &Organization,
 				Parameters: &models.V1SignTransactionIntent{
 					PrivateKeyID:        &signingKeyID,
 					Type:                &transactionType,

--- a/src/cmd/organizations.go
+++ b/src/cmd/organizations.go
@@ -48,7 +48,7 @@ var organizationsCreateCmd = &cobra.Command{
 
 		params := private_keys.NewPublicAPIServiceCreatePrivateKeysParams()
 		params.SetBody(&models.V1CreatePrivateKeysRequest{
-			OrganizationID: &privateKeysOrgID,
+			OrganizationID: &Organization,
 			Parameters: &models.V1CreatePrivateKeysIntent{
 				PrivateKeys: []*models.V1PrivateKeyParams{
 					{

--- a/src/cmd/private-keys.go
+++ b/src/cmd/private-keys.go
@@ -13,8 +13,6 @@ import (
 var (
 	signingKeyID string
 
-	privateKeysOrgID string
-
 	privateKeysCreateAddressFormats []string
 	privateKeysCreateCurve          string
 	privateKeysCreateName           string

--- a/src/cmd/raw.go
+++ b/src/cmd/raw.go
@@ -61,7 +61,7 @@ var rawSignCmd = &cobra.Command{
 
 		params := private_keys.NewPublicAPIServiceSignRawPayloadParams().WithBody(
 			&models.V1SignRawPayloadRequest{
-				OrganizationID: &privateKeysOrgID,
+				OrganizationID: &Organization,
 				Parameters: &models.V1SignRawPayloadIntent{
 					Encoding:     &payloadEncoding,
 					HashFunction: &hashFunction,

--- a/src/cmd/request.go
+++ b/src/cmd/request.go
@@ -12,7 +12,6 @@ import (
 	"github.com/spf13/cobra"
 
 	"github.com/tkhq/go-sdk/pkg/apikey"
-	"github.com/tkhq/go-sdk/pkg/store"
 )
 
 var (
@@ -37,15 +36,14 @@ var makeRequest = &cobra.Command{
 		and sends it to the Turnkey API server.
 		See options for alternate behavior, such as not sending the request.`,
 	Aliases: []string{"req", "r"},
+	PreRun: func(cmd *cobra.Command, args []string) {
+		basicSetup(cmd)
+		LoadKeypair("")
+	},
 	Run: func(cmd *cobra.Command, args []string) {
 		protocol := "https"
 		if pattern := regexp.MustCompile(`^localhost:\d+$`); pattern.MatchString(requestHost) {
 			protocol = "http"
-		}
-
-		apiKey, err := store.Default.Load(KeyName)
-		if err != nil {
-			OutputError(eris.Wrap(err, "failed to get API key"))
 		}
 
 		bodyReader, err := ParameterToReader(requestBody)
@@ -58,7 +56,7 @@ var makeRequest = &cobra.Command{
 			OutputError(eris.Wrap(err, "failed to read message body"))
 		}
 
-		stamp, err := apikey.Stamp(body, apiKey)
+		stamp, err := apikey.Stamp(body, APIKeypair)
 		if err != nil {
 			OutputError(eris.Wrap(err, "failed to produce a valid API stamp"))
 		}

--- a/src/main_test.go
+++ b/src/main_test.go
@@ -97,7 +97,9 @@ func TestKeygenDetectExistingKey(t *testing.T) {
 }
 
 func TestStamp(t *testing.T) {
-	out, err := RunCliWithArgs(t, []string{"request", "--no-post", "--key-name", "fixtures/testkey.private", "--body", "hello!"})
+	orgID := uuid.New()
+
+	out, err := RunCliWithArgs(t, []string{"request", "--no-post", "--keys-folder", ".", "--organization", orgID.String(), "--key-name", "fixtures/testkey.private", "--body", "hello!"})
 	assert.Nil(t, err)
 
 	var parsedOut map[string]string
@@ -113,7 +115,9 @@ func TestStamp(t *testing.T) {
 }
 
 func TestApproveRequest(t *testing.T) {
-	out, err := RunCliWithArgs(t, []string{"request", "--no-post", "--host", "api.turnkey.io", "--key-name", "fixtures/testkey.private", "--body", "{\"some\": \"field\"}", "--path", "/some/endpoint"})
+	orgID := uuid.New()
+
+	out, err := RunCliWithArgs(t, []string{"request", "--no-post", "--keys-folder", ".", "--organization", orgID.String(), "--key-name", "fixtures/testkey.private", "--body", "{\"some\": \"field\"}", "--path", "/some/endpoint"})
 	assert.Nil(t, err)
 
 	var parsedOut map[string]string
@@ -129,7 +133,7 @@ func TestApproveRequest(t *testing.T) {
 
 	assert.Contains(t, parsedOut["curlCommand"], "curl -X POST -d'{\"some\": \"field\"}'")
 	assert.Contains(t, parsedOut["curlCommand"], fmt.Sprintf("-H'X-Stamp: %s'", stamp))
-	assert.Contains(t, parsedOut["curlCommand"], "https://api.turnkey.io/some/endpoint")
+	assert.Contains(t, parsedOut["curlCommand"], "https://coordinator-beta.turnkey.io/some/endpoint")
 }
 
 func ensureValidStamp(t *testing.T, stamp string, expectedPublicKey string) {


### PR DESCRIPTION
The `request` subcommand was left out in the recent refactor of the keys-directory and API key loading systems.
This fixes that reversion.