### PR TITLE
Allow host override for all commands

### DIFF
--- a/src/cmd/auth.go
+++ b/src/cmd/auth.go
@@ -4,6 +4,7 @@ import (
 	"github.com/rotisserie/eris"
 
 	"github.com/tkhq/go-sdk"
+	"github.com/tkhq/go-sdk/pkg/api/client"
 	"github.com/tkhq/go-sdk/pkg/apikey"
 )
 
@@ -52,11 +53,11 @@ func LoadKeypair(name string) {
 
 // LoadClient creates an API client from the preloaded API keypair.
 func LoadClient() {
-	var err error
+	transportConfig := client.DefaultTransportConfig().WithHost(apiHost)
 
-	APIClient, err = sdk.New(APIKeypair.Name)
-
-	if err != nil {
-		OutputError(eris.Wrap(err, "failed to create API client"))
+	APIClient = &sdk.Client{
+		Client:        client.NewHTTPClientWithConfig(nil, transportConfig),
+		Authenticator: &sdk.Authenticator{Key: APIKeypair},
+		APIKey:        APIKeypair,
 	}
 }

--- a/src/cmd/request.go
+++ b/src/cmd/request.go
@@ -15,17 +15,16 @@ import (
 )
 
 var (
-	requestHost, requestPath, requestBody string
-	requestNoPost                         bool
+	requestPath, requestBody string
+	requestNoPost            bool
 )
 
 func init() {
-	makeRequest.Flags().StringVar(&requestHost, "host", "coordinator-beta.turnkey.io", "hostname of the API server")
-	makeRequest.Flags().StringVar(&requestPath, "path", "", "path for the API request")
 	makeRequest.Flags().StringVar(&requestBody, "body", "-", "body of the request, which can be '-' to indicate stdin or be prefixed with '@' to indicate a source filename")
 	makeRequest.Flags().BoolVar(&requestNoPost, "no-post", false, `generates the stamp and displays
 		the cURL command to use in order to perform this action,
 		but does NOT post the request to the API server`)
+	makeRequest.Flags().StringVar(&requestPath, "path", "", "path for the API request")
 
 	rootCmd.AddCommand(makeRequest)
 }
@@ -41,7 +40,7 @@ var makeRequest = &cobra.Command{
 	},
 	Run: func(cmd *cobra.Command, args []string) {
 		protocol := "https"
-		if pattern := regexp.MustCompile(`^localhost:\d+$`); pattern.MatchString(requestHost) {
+		if pattern := regexp.MustCompile(`^localhost:\d+$`); pattern.MatchString(apiHost) {
 			protocol = "http"
 		}
 
@@ -64,11 +63,11 @@ var makeRequest = &cobra.Command{
 			Output(map[string]string{
 				"message":     string(body),
 				"stamp":       stamp,
-				"curlCommand": generateCurlCommand(requestHost, requestPath, body, stamp),
+				"curlCommand": generateCurlCommand(apiHost, requestPath, body, stamp),
 			})
 		}
 
-		response, err := post(cmd.Context(), protocol, requestHost, requestPath, body, stamp)
+		response, err := post(cmd.Context(), protocol, apiHost, requestPath, body, stamp)
 		if err != nil {
 			OutputError(eris.Wrap(err, "failed to post request"))
 		}

--- a/src/cmd/root.go
+++ b/src/cmd/root.go
@@ -21,6 +21,8 @@ var (
 	// KeyName is the name of the key with which we are operating.
 	KeyName string
 
+	apiHost string
+
 	// Organization is the organization ID to interact with.
 	Organization string
 )
@@ -28,6 +30,7 @@ var (
 func init() {
 	rootCmd.PersistentFlags().StringVarP(&rootKeysDirectory, "keys-folder", "d", local.DefaultKeysDir(), "directory in which to locate keys")
 	rootCmd.PersistentFlags().StringVarP(&KeyName, "key-name", "k", "default", "name of API key with which to interact with the Turnkey API service")
+	rootCmd.PersistentFlags().StringVar(&apiHost, "host", "coordinator-beta.turnkey.io", "hostname of the API server")
 
 	rootCmd.PersistentFlags().StringVar(&Organization, "organization", "", "organization ID to be used")
 }


### PR DESCRIPTION
Allow the `--host` flag to work for all commands.

Fixes #30