### PR TITLE
Fix brew install instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,7 +58,7 @@ make install
 #### Brew
 
 ```sh
-brew tap tkhq/tkcli
+brew tap tkhq/tap
 brew install turnkey
 ```
 


### PR DESCRIPTION
Fixes #36 

The tap repo is here: https://github.com/tkhq/homebrew-tap