### PR TITLE
[easy] Update brew install instruction

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,8 +62,7 @@ make install
 #### Brew
 
 ```sh
-brew tap tkhq/tap
-brew install turnkey
+brew install tkhq/tap/turnkey
 ```
 
 ### Moderate Trust


### PR DESCRIPTION
## Summary & Motivation (Problem vs. Solution)
Inspiration: https://planetscale.com/docs/concepts/planetscale-environment-setup
<img width="406" alt="image" src="https://github.com/tkhq/tkcli/assets/127255904/85dc608a-efe3-4001-84ea-636933bf6cfe">

## How I tested it
```
$ brew install tkhq/tap/turnkey
Running `brew update --auto-update`...
==> Auto-updated Homebrew!
Updated 3 taps (tkhq/tap, homebrew/core and homebrew/cask).
==> New Formulae
core-lightning                  git-tools                       jsign                           lowdown                         mariadb@10.11
==> New Casks
apple-hewlett-packard-printer-drivers                grs-bluewallet                                       rode-connect
devpod                                               mumu-x

You have 64 outdated formulae installed.

turnkey v1.0.1 is already installed but outdated (so it will be upgraded).
==> Fetching tkhq/tap/turnkey
==> Downloading https://github.com/tkhq/tkcli/raw/v1.0.2/dist/turnkey.darwin-aarch64
==> Downloading from https://media.githubusercontent.com/media/tkhq/tkcli/v1.0.2/dist/turnkey.darwin-aarch64
####################################################################################################################################################### 100.0%
==> Upgrading tkhq/tap/turnkey
  v1.0.1 -> v1.0.2

🍺  /opt/homebrew/Cellar/turnkey/v1.0.2: 3 files, 14.7MB, built in 1 second
==> Running `brew cleanup turnkey`...
Disable this behaviour by setting HOMEBREW_NO_INSTALL_CLEANUP.
Hide these hints with HOMEBREW_NO_ENV_HINTS (see `man brew`).
Removing: /opt/homebrew/Cellar/turnkey/v1.0.1... (3 files, 14.7MB)
Removing: /Users/keyan/Library/Caches/Homebrew/turnkey--v1.0.1.darwin-aarch64... (14.7MB)

```