### PR TITLE
fix private-keys create

### DIFF
--- a/src/cmd/turnkey/pkg/private-keys.go
+++ b/src/cmd/turnkey/pkg/private-keys.go
@@ -74,7 +74,7 @@ var privateKeysCreateCmd = &cobra.Command{
 			addressFormats[n] = models.AddressFormat(f)
 		}
 
-		activity := string(models.ActivityTypeCreatePrivateKeys)
+		activity := string(models.ActivityTypeCreatePrivateKeysV2)
 
 		params := private_keys.NewCreatePrivateKeysParams()
 		params.SetBody(&models.CreatePrivateKeysRequest{


### PR DESCRIPTION
## Summary & Motivation (Problem vs. Solution)
Fixes this issue:

```
turnkey private-keys create --address-format ADDRESS_FORMAT_ETHEREUM --curve CURVE_SECP256K1 --name yolo
{
   "error": "request validation failed: validation failure list:\ntype in body should be one of [ACTIVITY_TYPE_CREATE_PRIVATE_KEYS_V2]"
}
```

## Release Steps
See README for additional details.

- [ ] Tag the release (once approved)
- [ ] Attest (once merged)
- [ ] Create release with changelog
- [ ] Update Homebrew tap
