### PR TITLE
Apply key formatting to encrypt command

### DIFF
--- a/src/cmd/turnkey/pkg/encrypt.go
+++ b/src/cmd/turnkey/pkg/encrypt.go
@@ -103,7 +103,7 @@ var encryptCmd = &cobra.Command{
 		}
 
 		// encrypt plaintext
-		clientSendMsg, err := encryptClient.Encrypt([]byte(plaintextBytes), serverTargetMsg)
+		clientSendMsg, err := encryptClient.Encrypt(plaintextBytes, serverTargetMsg)
 		if err != nil {
 			OutputError(err)
 		}


### PR DESCRIPTION
## Summary & Motivation (Problem vs. Solution)
Add `--key-format` flag for `encrypt` command that accepts `mnemonic` (default), `hexadecimal`, and `solana`.
```
turnkey encrypt \
--import-bundle-input "./import_bundle.txt" \
--encrypted-bundle-output "./encrypted_bundle.txt" \
--plaintext-input /dev/fd/3 3<<<"$SEEDPHRASE_1"
--key-format "mnemonic"
```

Tested the following scenarios:
* encrypt mnemonic with no `--key-format` flag then import wallet ✅ 
* encrypt mnemonic with `--key-format mnemonic` flag then import wallet ✅ 
* encrypt hex-encoded hex key with `--key-format hexadecimal` flag then import key w ethereum address format and secp256k1 curve ✅ 
* encrypt phantom solana key with `--key-format solana` flag then import key w solana address format and ed25519 curve ✅ 

## Release Steps
See README for additional details.

- [ ] Tag the release (once approved)
- [ ] Attest (once merged)
- [ ] Create release with changelog
- [ ] Update Homebrew tap
