### PR TITLE
Part 2/3: Verifiable metadata

### DIFF
--- a/src/cmd/turnkey/pkg/encrypt.go
+++ b/src/cmd/turnkey/pkg/encrypt.go
@@ -33,6 +33,7 @@ func init() {
 	encryptCmd.Flags().StringVar(&encryptedBundlePath, "encrypted-bundle-output", "", "filepath to read the encrypted bundle from.")
 	encryptCmd.Flags().StringVar(&plaintextPath, "plaintext-input", "", "filepath to read the plaintext from that will be encrypted.")
 	encryptCmd.Flags().StringVar(&keyFormat, "key-format", "mnemonic", "optional formatting to apply to the plaintext before it is encrypted.")
+	encryptCmd.Flags().StringVar(&user, "user", "", "ID of user to encrypting the plaintext.")
 
 	rootCmd.AddCommand(encryptCmd)
 }
@@ -57,12 +58,6 @@ var encryptCmd = &cobra.Command{
 	Run: func(cmd *cobra.Command, args []string) {
 		// read from import bundle path
 		importBundle, err := readFile(importBundlePath)
-		if err != nil {
-			OutputError(err)
-		}
-
-		var serverTargetMsg enclave_encrypt.ServerTargetMsg
-		err = json.Unmarshal([]byte(importBundle), &serverTargetMsg)
 		if err != nil {
 			OutputError(err)
 		}
@@ -103,7 +98,7 @@ var encryptCmd = &cobra.Command{
 		}
 
 		// encrypt plaintext
-		clientSendMsg, err := encryptClient.Encrypt(plaintextBytes, serverTargetMsg)
+		clientSendMsg, err := encryptClient.Encrypt(plaintextBytes, []byte(importBundle), Organization, &user)
 		if err != nil {
 			OutputError(err)
 		}

--- a/src/go.mod
+++ b/src/go.mod
@@ -5,18 +5,18 @@ go 1.21
 toolchain go1.21.0
 
 require (
+	github.com/btcsuite/btcutil v1.0.2
 	github.com/google/uuid v1.3.1
 	github.com/rotisserie/eris v0.5.4
 	github.com/spf13/cobra v1.7.0
 	github.com/stretchr/testify v1.8.4
-	github.com/tkhq/go-sdk v0.0.0-20240306173256-cde2ffbe3c7a
-	github.com/tkhq/go-sdk/pkg/enclave_encrypt v0.0.0-20240309210249-e589efc314fb
+	github.com/tkhq/go-sdk v0.0.0-20240409013829-672064f648db
+	github.com/tkhq/go-sdk/pkg/enclave_encrypt v0.0.0-20240409013829-672064f648db
 	gopkg.in/yaml.v3 v3.0.1
 )
 
 require (
 	github.com/asaskevich/govalidator v0.0.0-20230301143203-a9d515a09cc2 // indirect
-	github.com/btcsuite/btcutil v1.0.2 // indirect
 	github.com/cloudflare/circl v1.3.7 // indirect
 	github.com/davecgh/go-spew v1.1.2-0.20180830191138-d8f796af33cc // indirect
 	github.com/go-logr/logr v1.2.4 // indirect

--- a/src/go.sum
+++ b/src/go.sum
@@ -184,10 +184,12 @@ github.com/stretchr/testify v1.8.1/go.mod h1:w2LPCIKwWwSfY2zedu0+kehJoqGctiVI29o
 github.com/stretchr/testify v1.8.4 h1:CcVxjf3Q8PM0mHUKJCdn+eZZtm5yQwehR5yeSVQQcUk=
 github.com/stretchr/testify v1.8.4/go.mod h1:sz/lmYIOXD/1dqDmKjjqLyZ2RngseejIcXlSw2iwfAo=
 github.com/tidwall/pretty v1.0.0/go.mod h1:XNkn88O1ChpSDQmQeStsy+sBenx6DDtFZJxhVysOjyk=
-github.com/tkhq/go-sdk v0.0.0-20240306173256-cde2ffbe3c7a h1:Qouvo+9386g2hvL5RtTy6XCD6huunSh8/GCM2e9z6Ec=
-github.com/tkhq/go-sdk v0.0.0-20240306173256-cde2ffbe3c7a/go.mod h1:dXWbe9UgF04/cdHHSHgiqVZQS71rFw21hbiY4RIU0ps=
+github.com/tkhq/go-sdk v0.0.0-20240409013829-672064f648db h1:dL4YjpzkATt15Yg/w1HEJs+PYUUf/byPDneDIbJhWbU=
+github.com/tkhq/go-sdk v0.0.0-20240409013829-672064f648db/go.mod h1:dXWbe9UgF04/cdHHSHgiqVZQS71rFw21hbiY4RIU0ps=
 github.com/tkhq/go-sdk/pkg/enclave_encrypt v0.0.0-20240309210249-e589efc314fb h1:INibZZ7BDURpkTKftXCIuOYNELjsrIUsEmrtKe4ffpc=
 github.com/tkhq/go-sdk/pkg/enclave_encrypt v0.0.0-20240309210249-e589efc314fb/go.mod h1:BvoxNhFz61TSwjbULvHYdeV0aS68qkcHXpGkJFVkzrw=
+github.com/tkhq/go-sdk/pkg/enclave_encrypt v0.0.0-20240409013829-672064f648db h1:QQy2N8vGZjSqevBDlmOyeWGpk9xIXcsznw4CHjrXRZs=
+github.com/tkhq/go-sdk/pkg/enclave_encrypt v0.0.0-20240409013829-672064f648db/go.mod h1:BvoxNhFz61TSwjbULvHYdeV0aS68qkcHXpGkJFVkzrw=
 github.com/xdg-go/pbkdf2 v1.0.0/go.mod h1:jrpuAogTd400dnrH08LKmI/xc1MbPOebTwRqcT5RDeI=
 github.com/xdg-go/scram v1.0.2/go.mod h1:1WAq6h33pAW+iRreB34OORO2Nf7qel3VV3fjBj+hCSs=
 github.com/xdg-go/scram v1.1.1/go.mod h1:RaEWvsqvNKKvBPvcKeFjrG2cJqOkHTiyTpzz23ni57g=


### PR DESCRIPTION
## Summary & Motivation (Problem vs. Solution)
Use the latest version of the go-sdk enclave-encrypt package which verifies the entire data object containing metadata like the organization id and user id.

Part 1a: https://github.com/tkhq/sdk/pull/233
Part 1b:  https://github.com/tkhq/frames/pull/33
Part 1c: https://github.com/tkhq/go-sdk/pull/47
Part 2: https://github.com/tkhq/tkcli/pull/59
Part 3: https://github.com/tkhq/mono/pull/2806

## Release Steps
See README for additional details.

- [ ] Tag the release (once approved)
- [ ] Attest (once merged)
- [ ] Create release with changelog
- [ ] Update Homebrew tap
