### PR TITLE
Adding support for secp256k1 and ed25519 keys

### DIFF
--- a/src/cmd/turnkey/pkg/generate.go
+++ b/src/cmd/turnkey/pkg/generate.go
@@ -90,7 +90,7 @@ var apiKeyCmd = &cobra.Command{
 			OutputError(eris.Wrap(err, "failed to store new API keypair"))
 		}
 
-		localStore, ok := apiKeyStore.(*local.Store[apikey.Key, apikey.Metadata])
+		localStore, ok := apiKeyStore.(*local.Store[*apikey.Key, apikey.Metadata])
 		if !ok {
 			OutputError(eris.Wrap(err, "unhandled keystore type: expected *local.Store"))
 		}
@@ -144,7 +144,7 @@ var encryptionKeyCmd = &cobra.Command{
 			OutputError(eris.Wrap(err, "failed to store new encryption keypair"))
 		}
 
-		localStore, ok := encryptionKeyStore.(*local.Store[encryptionkey.Key, encryptionkey.Metadata])
+		localStore, ok := encryptionKeyStore.(*local.Store[*encryptionkey.Key, encryptionkey.Metadata])
 		if !ok {
 			OutputError(eris.Wrap(err, "unhandled keystore type: expected *local.Store"))
 		}

--- a/src/cmd/turnkey/pkg/generate.go
+++ b/src/cmd/turnkey/pkg/generate.go
@@ -58,17 +58,17 @@ var apiKeyCmd = &cobra.Command{
 		default:
 			OutputError(fmt.Errorf("invalid curve type: %s; supported types are p256, secp256k1, and ed25519", curveType))
 		case "p256":
-			apiKey, err = apikey.New(Organization, apikey.SchemeP256)
+			apiKey, err = apikey.New(Organization, apikey.WithScheme(apikey.SchemeP256))
 			if err != nil {
 				OutputError(eris.Wrap(err, "failed to create API keypair"))
 			}
 		case "secp256k1":
-			apiKey, err = apikey.New(Organization, apikey.SchemeSECP256K1)
+			apiKey, err = apikey.New(Organization, apikey.WithScheme(apikey.SchemeSECP256K1))
 			if err != nil {
 				OutputError(eris.Wrap(err, "failed to create API keypair"))
 			}
 		case "ed25519":
-			apiKey, err = apikey.New(Organization, apikey.SchemeED25519)
+			apiKey, err = apikey.New(Organization, apikey.WithScheme(apikey.SchemeED25519))
 			if err != nil {
 				OutputError(eris.Wrap(err, "failed to create API keypair"))
 			}

--- a/src/cmd/turnkey/pkg/generate.go
+++ b/src/cmd/turnkey/pkg/generate.go
@@ -57,17 +57,17 @@ var apiKeyCmd = &cobra.Command{
 		switch curveType {
 		default:
 			OutputError(fmt.Errorf("invalid curve type: %s; supported types are p256, secp256k1, and ed25519", curveType))
-		case "p256":
+		case string(apikey.CurveP256):
 			apiKey, err = apikey.New(Organization, apikey.WithScheme(apikey.SchemeP256))
 			if err != nil {
 				OutputError(eris.Wrap(err, "failed to create API keypair"))
 			}
-		case "secp256k1":
+		case string(apikey.CurveSecp256k1):
 			apiKey, err = apikey.New(Organization, apikey.WithScheme(apikey.SchemeSECP256K1))
 			if err != nil {
 				OutputError(eris.Wrap(err, "failed to create API keypair"))
 			}
-		case "ed25519":
+		case string(apikey.CurveEd25519):
 			apiKey, err = apikey.New(Organization, apikey.WithScheme(apikey.SchemeED25519))
 			if err != nil {
 				OutputError(eris.Wrap(err, "failed to create API keypair"))

--- a/src/cmd/turnkey/pkg/generate.go
+++ b/src/cmd/turnkey/pkg/generate.go
@@ -16,7 +16,7 @@ var (
 )
 
 func init() {
-	apiKeyCmd.Flags().StringVar(&curveType, "curve", "p256", "curve type for API key; p256 and secp256k1 currently supported")
+	apiKeyCmd.Flags().StringVar(&curveType, "curve", "p256", "curve type for API key; p256, secp256k1, and ed25519 currently supported")
 	generateCmd.AddCommand(apiKeyCmd)
 
 	encryptionKeyCmd.Flags().StringVar(&User, "user", "", "ID of user to generating the encryption key")
@@ -56,7 +56,7 @@ var apiKeyCmd = &cobra.Command{
 
 		switch curveType {
 		default:
-			OutputError(fmt.Errorf("invalid curve type: %s; supported types are p256 and secp256k1", curveType))
+			OutputError(fmt.Errorf("invalid curve type: %s; supported types are p256, secp256k1, and ed25519", curveType))
 		case "p256":
 			apiKey, err = apikey.New(Organization, apikey.SchemeP256)
 			if err != nil {
@@ -64,6 +64,11 @@ var apiKeyCmd = &cobra.Command{
 			}
 		case "secp256k1":
 			apiKey, err = apikey.New(Organization, apikey.SchemeSECP256K1)
+			if err != nil {
+				OutputError(eris.Wrap(err, "failed to create API keypair"))
+			}
+		case "ed25519":
+			apiKey, err = apikey.New(Organization, apikey.SchemeED25519)
 			if err != nil {
 				OutputError(eris.Wrap(err, "failed to create API keypair"))
 			}

--- a/src/cmd/turnkey/pkg/root.go
+++ b/src/cmd/turnkey/pkg/root.go
@@ -29,9 +29,9 @@ var (
 
 	encryptionKeysDirectory string
 
-	apiKeyStore store.Store[apikey.Key, apikey.Metadata]
+	apiKeyStore store.Store[*apikey.Key, apikey.Metadata]
 
-	encryptionKeyStore store.Store[encryptionkey.Key, encryptionkey.Metadata]
+	encryptionKeyStore store.Store[*encryptionkey.Key, encryptionkey.Metadata]
 
 	// ApiKeyName is the name of the key with which we are operating.
 	ApiKeyName string
@@ -70,7 +70,7 @@ func basicSetup(cmd *cobra.Command) {
 	}
 
 	if apiKeyStore == nil {
-		localApiKeyStore := local.New[apikey.Key, apikey.Metadata]()
+		localApiKeyStore := local.New[*apikey.Key, apikey.Metadata]()
 
 		if err := localApiKeyStore.SetAPIKeysDirectory(apiKeysDirectory); err != nil {
 			OutputError(eris.Wrap(err, "failed to obtain API key storage location"))
@@ -80,7 +80,7 @@ func basicSetup(cmd *cobra.Command) {
 	}
 
 	if encryptionKeyStore == nil {
-		localEncryptionKeyStore := local.New[encryptionkey.Key, encryptionkey.Metadata]()
+		localEncryptionKeyStore := local.New[*encryptionkey.Key, encryptionkey.Metadata]()
 
 		if err := localEncryptionKeyStore.SetEncryptionKeysDirectory(encryptionKeysDirectory); err != nil {
 			OutputError(eris.Wrap(err, "failed to obtain encryption key storage location"))

--- a/src/go.mod
+++ b/src/go.mod
@@ -4,6 +4,8 @@ go 1.21
 
 toolchain go1.21.0
 
+replace github.com/tkhq/go-sdk => /Users/robin/src/code/go-sdk
+
 require (
 	github.com/btcsuite/btcutil v1.0.2
 	github.com/google/uuid v1.3.1

--- a/src/go.mod
+++ b/src/go.mod
@@ -4,8 +4,6 @@ go 1.21
 
 toolchain go1.21.0
 
-replace github.com/tkhq/go-sdk => /Users/robin/src/code/go-sdk
-
 require (
 	github.com/btcsuite/btcutil v1.0.2
 	github.com/google/uuid v1.3.1

--- a/src/go.mod
+++ b/src/go.mod
@@ -4,15 +4,13 @@ go 1.21
 
 toolchain go1.21.0
 
-replace github.com/tkhq/go-sdk => /Users/robin/src/code/go-sdk
-
 require (
 	github.com/btcsuite/btcutil v1.0.2
 	github.com/google/uuid v1.3.1
 	github.com/rotisserie/eris v0.5.4
 	github.com/spf13/cobra v1.7.0
 	github.com/stretchr/testify v1.8.4
-	github.com/tkhq/go-sdk v0.0.0-20240513225018-5ebfb539ec1e
+	github.com/tkhq/go-sdk v0.0.0-20240813182504-228a50933080
 	github.com/tkhq/go-sdk/pkg/enclave_encrypt v0.0.0-20240513225018-5ebfb539ec1e
 	gopkg.in/yaml.v3 v3.0.1
 )

--- a/src/go.mod
+++ b/src/go.mod
@@ -10,7 +10,7 @@ require (
 	github.com/rotisserie/eris v0.5.4
 	github.com/spf13/cobra v1.7.0
 	github.com/stretchr/testify v1.8.4
-	github.com/tkhq/go-sdk v0.0.0-20240813182504-228a50933080
+	github.com/tkhq/go-sdk v0.0.0-20240813203011-ed45fe0d5c27
 	github.com/tkhq/go-sdk/pkg/enclave_encrypt v0.0.0-20240513225018-5ebfb539ec1e
 	gopkg.in/yaml.v3 v3.0.1
 )

--- a/src/go.mod
+++ b/src/go.mod
@@ -21,6 +21,8 @@ require (
 	github.com/asaskevich/govalidator v0.0.0-20230301143203-a9d515a09cc2 // indirect
 	github.com/cloudflare/circl v1.3.7 // indirect
 	github.com/davecgh/go-spew v1.1.2-0.20180830191138-d8f796af33cc // indirect
+	github.com/decred/dcrd/dcrec/secp256k1/v4 v4.0.1 // indirect
+	github.com/ethereum/go-ethereum v1.14.5 // indirect
 	github.com/go-logr/logr v1.2.4 // indirect
 	github.com/go-logr/stdr v1.2.2 // indirect
 	github.com/go-openapi/analysis v0.21.4 // indirect
@@ -46,7 +48,7 @@ require (
 	go.opentelemetry.io/otel v1.19.0 // indirect
 	go.opentelemetry.io/otel/metric v1.19.0 // indirect
 	go.opentelemetry.io/otel/trace v1.19.0 // indirect
-	golang.org/x/crypto v0.18.0 // indirect
-	golang.org/x/sys v0.16.0 // indirect
+	golang.org/x/crypto v0.22.0 // indirect
+	golang.org/x/sys v0.20.0 // indirect
 	gopkg.in/yaml.v2 v2.4.0 // indirect
 )

--- a/src/go.sum
+++ b/src/go.sum
@@ -24,6 +24,11 @@ github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSs
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/davecgh/go-spew v1.1.2-0.20180830191138-d8f796af33cc h1:U9qPSI2PIWSS1VwoXQT9A3Wy9MM3WgvqSxFWenqJduM=
 github.com/davecgh/go-spew v1.1.2-0.20180830191138-d8f796af33cc/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
+github.com/decred/dcrd/crypto/blake256 v1.0.0/go.mod h1:sQl2p6Y26YV+ZOcSTP6thNdn47hh8kt6rqSlvmrXFAc=
+github.com/decred/dcrd/dcrec/secp256k1/v4 v4.0.1 h1:YLtO71vCjJRCBcrPMtQ9nqBsqpA1m5sE92cU+pd5Mcc=
+github.com/decred/dcrd/dcrec/secp256k1/v4 v4.0.1/go.mod h1:hyedUtir6IdtD/7lIxGeCxkaw7y45JueMRL4DIyJDKs=
+github.com/ethereum/go-ethereum v1.14.5 h1:szuFzO1MhJmweXjoM5nSAeDvjNUH3vIQoMzzQnfvjpw=
+github.com/ethereum/go-ethereum v1.14.5/go.mod h1:VEDGGhSxY7IEjn98hJRFXl/uFvpRgbIIf2PpXiyGGgc=
 github.com/fsnotify/fsnotify v1.4.7/go.mod h1:jwhsz4b93w/PPRr/qN1Yymfu8t87LnFCMoQvtojpjFo=
 github.com/go-logr/logr v1.2.2/go.mod h1:jdQByPbusPIv2/zmleS9BjJVeZ6kBagPoEUsqbVz/1A=
 github.com/go-logr/logr v1.2.4 h1:g01GSCwiDw2xSZfjJ2/T9M+S6pFdcNtFYsp+Y43HYDQ=
@@ -184,8 +189,6 @@ github.com/stretchr/testify v1.8.1/go.mod h1:w2LPCIKwWwSfY2zedu0+kehJoqGctiVI29o
 github.com/stretchr/testify v1.8.4 h1:CcVxjf3Q8PM0mHUKJCdn+eZZtm5yQwehR5yeSVQQcUk=
 github.com/stretchr/testify v1.8.4/go.mod h1:sz/lmYIOXD/1dqDmKjjqLyZ2RngseejIcXlSw2iwfAo=
 github.com/tidwall/pretty v1.0.0/go.mod h1:XNkn88O1ChpSDQmQeStsy+sBenx6DDtFZJxhVysOjyk=
-github.com/tkhq/go-sdk v0.0.0-20240513225018-5ebfb539ec1e h1:sO/sz9Jsmdbh9VEpil3KLE3DfJzHBKiRPVQy4koZH9A=
-github.com/tkhq/go-sdk v0.0.0-20240513225018-5ebfb539ec1e/go.mod h1:NgCPbnpGdhx+31NLwmK3iC6UftT7I70dbKXVbblVpjk=
 github.com/tkhq/go-sdk/pkg/enclave_encrypt v0.0.0-20240513225018-5ebfb539ec1e h1:6TQn08QGF615Bt2LRNv1MwlI5qL9NlpO2A/DIKX8MUo=
 github.com/tkhq/go-sdk/pkg/enclave_encrypt v0.0.0-20240513225018-5ebfb539ec1e/go.mod h1:BvoxNhFz61TSwjbULvHYdeV0aS68qkcHXpGkJFVkzrw=
 github.com/xdg-go/pbkdf2 v1.0.0/go.mod h1:jrpuAogTd400dnrH08LKmI/xc1MbPOebTwRqcT5RDeI=
@@ -218,8 +221,8 @@ golang.org/x/crypto v0.0.0-20200115085410-6d4e4cb37c7d/go.mod h1:LzIPMQfyMNhhGPh
 golang.org/x/crypto v0.0.0-20200302210943-78000ba7a073/go.mod h1:LzIPMQfyMNhhGPhUkYOs5KpL4U8rLKemX1yGLhDgUto=
 golang.org/x/crypto v0.0.0-20210921155107-089bfa567519/go.mod h1:GvvjBRRGRdwPK5ydBHafDWAxML/pGHZbMvKqRZ5+Abc=
 golang.org/x/crypto v0.0.0-20220622213112-05595931fe9d/go.mod h1:IxCIyHEi3zRg3s0A5j5BB6A9Jmi73HwBIUl50j+osU4=
-golang.org/x/crypto v0.18.0 h1:PGVlW0xEltQnzFZ55hkuX5+KLyrMYhHld1YHO4AKcdc=
-golang.org/x/crypto v0.18.0/go.mod h1:R0j02AL6hcrfOiy9T4ZYp/rcWeMxM3L6QYxlOuEG1mg=
+golang.org/x/crypto v0.22.0 h1:g1v0xeRhjcugydODzvb3mEM9SQ0HGp9s/nh3COQ/C30=
+golang.org/x/crypto v0.22.0/go.mod h1:vr6Su+7cTlO45qkww3VDJlzDn0ctJvRgYbC2NvXHt+M=
 golang.org/x/mod v0.6.0-dev.0.20220419223038-86c51ed26bb4/go.mod h1:jJ57K6gSWd91VN4djpZkiMVwK6gcyfeH4XE8wZrZaV4=
 golang.org/x/net v0.0.0-20180906233101-161cd47e91fd/go.mod h1:mL1N/T3taQHkDXs73rZJwtUhF3w3ftmwwsq0BUmARs4=
 golang.org/x/net v0.0.0-20190311183353-d8887717615a/go.mod h1:t9HGtf8HONx5eT2rtn7q6eTqICYqUVnKs3thJo3Qplg=
@@ -250,8 +253,8 @@ golang.org/x/sys v0.0.0-20210423082822-04245dca01da/go.mod h1:h1NjWce9XRLGQEsW7w
 golang.org/x/sys v0.0.0-20210615035016-665e8c7367d1/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/sys v0.0.0-20220520151302-bc2c85ada10a/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/sys v0.0.0-20220722155257-8c9f86f7a55f/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
-golang.org/x/sys v0.16.0 h1:xWw16ngr6ZMtmxDyKyIgsE93KNKz5HKmMa3b8ALHidU=
-golang.org/x/sys v0.16.0/go.mod h1:/VUhepiaJMQUp4+oa/7Zr1D23ma6VTLIYjOOTFZPUcA=
+golang.org/x/sys v0.20.0 h1:Od9JTbYCk261bKm4M/mw7AklTlFYIa0bIp9BgSm1S8Y=
+golang.org/x/sys v0.20.0/go.mod h1:/VUhepiaJMQUp4+oa/7Zr1D23ma6VTLIYjOOTFZPUcA=
 golang.org/x/term v0.0.0-20201126162022-7de9c90e9dd1/go.mod h1:bj7SfCRtBDWHUb9snDiAeCFNEtKQo2Wmx5Cou7ajbmo=
 golang.org/x/term v0.0.0-20210927222741-03fcf44c2211/go.mod h1:jbD1KX2456YbFQfuXm/mYQcufACuNUgVhRMnK/tPxf8=
 golang.org/x/text v0.3.0/go.mod h1:NqM8EUOU14njkJ3fqMW+pc6Ldnwhi/IjpwHt7yyuwOQ=

--- a/src/go.sum
+++ b/src/go.sum
@@ -189,6 +189,10 @@ github.com/stretchr/testify v1.8.1/go.mod h1:w2LPCIKwWwSfY2zedu0+kehJoqGctiVI29o
 github.com/stretchr/testify v1.8.4 h1:CcVxjf3Q8PM0mHUKJCdn+eZZtm5yQwehR5yeSVQQcUk=
 github.com/stretchr/testify v1.8.4/go.mod h1:sz/lmYIOXD/1dqDmKjjqLyZ2RngseejIcXlSw2iwfAo=
 github.com/tidwall/pretty v1.0.0/go.mod h1:XNkn88O1ChpSDQmQeStsy+sBenx6DDtFZJxhVysOjyk=
+github.com/tkhq/go-sdk v0.0.0-20240813182504-228a50933080 h1:Yhc2J2GCB0SDbLBVwK1ZlrYNiHVuwHGCU+N9CdJz4WQ=
+github.com/tkhq/go-sdk v0.0.0-20240813182504-228a50933080/go.mod h1:NgCPbnpGdhx+31NLwmK3iC6UftT7I70dbKXVbblVpjk=
+github.com/tkhq/go-sdk v0.0.0-20240813203011-ed45fe0d5c27 h1:1Tm6Z2uD9THuycnXtkNbTMf07Owdm071fV5JcKLsAQE=
+github.com/tkhq/go-sdk v0.0.0-20240813203011-ed45fe0d5c27/go.mod h1:2372WQ2x5SWlXmFBygP8PaNcR225Pn8Nd2WmzT9E35Y=
 github.com/tkhq/go-sdk/pkg/enclave_encrypt v0.0.0-20240513225018-5ebfb539ec1e h1:6TQn08QGF615Bt2LRNv1MwlI5qL9NlpO2A/DIKX8MUo=
 github.com/tkhq/go-sdk/pkg/enclave_encrypt v0.0.0-20240513225018-5ebfb539ec1e/go.mod h1:BvoxNhFz61TSwjbULvHYdeV0aS68qkcHXpGkJFVkzrw=
 github.com/xdg-go/pbkdf2 v1.0.0/go.mod h1:jrpuAogTd400dnrH08LKmI/xc1MbPOebTwRqcT5RDeI=


### PR DESCRIPTION
## Summary & Motivation (Problem vs. Solution)

Per the [most recent GoSDK update](https://github.com/tkhq/go-sdk/pull/57), Turnkey now supports secp256k1 and ed25519 curves for API keys. This PR extends the TKCLI's functionality to allow keys in these new curves to be generated and used as signers for Turnkey requests.

## Release Steps
See README for additional details.

- [ ] Tag the release (once approved)
- [ ] Attest (once merged)
- [ ] Create release with changelog
- [ ] Update Homebrew tap
