### PR TITLE
Fix required flag name in `wallet account list` error message

### DIFF
--- a/src/cmd/turnkey/pkg/wallets.go
+++ b/src/cmd/turnkey/pkg/wallets.go
@@ -502,7 +502,7 @@ var walletAccountsListCmd = &cobra.Command{
 	Short: "Return accounts for the wallet",
 	PreRun: func(cmd *cobra.Command, args []string) {
 		if walletNameOrID == "" {
-			OutputError(eris.New("--name must be specified"))
+			OutputError(eris.New("--wallet must be specified"))
 		}
 	},
 	Run: func(cmd *cobra.Command, args []string) {


### PR DESCRIPTION
## Summary & Motivation (Problem vs. Solution)

This is a tiny copy change. 

The CLI currently responds with "--name must be specified", but the `wallet accounts list` command uses [`--wallet` as the flag](https://github.com/tkhq/tkcli/blob/main/src/cmd/turnkey/pkg/wallets.go#L41).