### PR TITLE
Update README, correct outdated 'usage' instructions, fix: #100

### DIFF
--- a/README.md
+++ b/README.md
@@ -157,7 +157,6 @@ to attempt to force one or more of us to tamper with the software.
    ```
 
 2. Review source
-
    - Ideal: Review the entire supply chain is recommended for high risk uses
    - Minimal: review the "attest" "sign" and "verify" targets in the Makefile
 
@@ -194,10 +193,10 @@ to attempt to force one or more of us to tamper with the software.
 
 ## Usage
 
-Create a new API key:
+### Generate a new API key
 
 ```sh
-$ turnkey generate api-key --organization $ORGANIZATION_ID
+$ turnkey generate api-key --organization $ORGANIZATION_ID --key-name default
 {
    "privateKeyFile": "/Users/andrew/Library/Application Support/turnkey/keys/default.private",
    "publicKey": "0236f17892a4649d97b2e4a4ad3c22d815e4e77848a0b8e4a5b0956ae4d6be382e",
@@ -205,34 +204,16 @@ $ turnkey generate api-key --organization $ORGANIZATION_ID
 }
 ```
 
-Make an API request (using the default API key created above):
+### Add your public API key
 
-```sh
-$ turnkey request --path /api/v1/sign --body '{"payload": "hello from TKHQ"}'
-{
-    "result": "I am a teapot"
-}
-```
+As an authenticated user on the Turnkey dashboard, navigate to your user page by clicking on "User Details" in the user dropdown menu.
 
-If you need to sign a request with a different key, use the `--key-name` and/or `--keys-folder` flags:
+Click on "Create API keys and follow the prompts to add the generated public API key. You'll be required to authenticate with the same authenticator used during onboarding. After this succeeds, you should be all set to interact with our API.
 
-```sh
-$ turnkey request --path /api/v1/sign --body '{"payload": "hello from TKHQ"}' --keys-folder /path/to/keys --key-name another-key
-{
-    "result": "I am a teapot"
-}
-```
+#### Notes
 
-Create, but do not _post_ a request:
-
-```sh
-$ turnkey request --no-post --path /api/v1/sign --body '{"payload": "hello from TKHQ"}'
-{
-    "curlCommand": "curl -X POST -d'{\"payload\": \"hello from TKHQ\"}' -H'X-Stamp: eyJwdWJsaWNLZXkiOiIwM2JmMTYyNTc2ZWI4ZGZlY2YzM2Q5Mjc1ZDA5NTk1Mjg0ZjZjNGRmMGRiNjE1NmMzYzU4Mjc3Nzg4NmEwZWUwYWMiLCJzaWduYXR1cmUiOiIzMDQ0MDIyMDZiMmRlYmIwYjA3YmYwMDJlMjI1ZmQ4NTgzZjZmNGUxNGE5YTUxYWRiYWJjNDAyYzY5YTZlN2Q4N2ViNWNjMDgwMjIwMjE0ZTdkMGJlODFjMGYyNDEyOWE0MmNkZGFlOTUxYTBmZTViMGM1Mzc3YjM2NzZiOTUyNDgyNmYwODdhMWU4ZiIsInNjaGVtZSI6IlNJR05BVFVSRV9TQ0hFTUVfVEtfQVBJX1AyNTYifQ' -v 'https://coordinator-beta.turnkey.io/api/v1/sign'",
-    "message": "{\"payload\": \"hello from TKHQ\"}",
-    "stamp": "eyJwdWJsaWNLZXkiOiIwM2JmMTYyNTc2ZWI4ZGZlY2YzM2Q5Mjc1ZDA5NTk1Mjg0ZjZjNGRmMGRiNjE1NmMzYzU4Mjc3Nzg4NmEwZWUwYWMiLCJzaWduYXR1cmUiOiIzMDQ0MDIyMDZiMmRlYmIwYjA3YmYwMDJlMjI1ZmQ4NTgzZjZmNGUxNGE5YTUxYWRiYWJjNDAyYzY5YTZlN2Q4N2ViNWNjMDgwMjIwMjE0ZTdkMGJlODFjMGYyNDEyOWE0MmNkZGFlOTUxYTBmZTViMGM1Mzc3YjM2NzZiOTUyNDgyNmYwODdhMWU4ZiIsInNjaGVtZSI6IlNJR05BVFVSRV9TQ0hFTUVfVEtfQVBJX1AyNTYifQ"
-}
-```
+- If you would like to manually copy your locally-stored public/private API key files (e.g. `default.public`, `default.private`), you will have to save the files without newlines (which occupy extra bytes). For example, for VIM, use `:set binary noeol` or `:set binary noendofline` before writing.
+- Only P-256 keys (`API_KEY_CURVE_P256`) are currently supported.
 
 ## Building
 

--- a/README.md
+++ b/README.md
@@ -215,6 +215,49 @@ Click on "Create API keys and follow the prompts to add the generated public API
 - If you would like to manually copy your locally-stored public/private API key files (e.g. `default.public`, `default.private`), you will have to save the files without newlines (which occupy extra bytes). For example, for VIM, use `:set binary noeol` or `:set binary noendofline` before writing.
 - Only P-256 keys (`API_KEY_CURVE_P256`) are currently supported.
 
+### Create a Wallet
+
+Wallets are collections of cryptographic key pairs typically used for sending and receiving digital assets. To create on, we need to provide a name:
+
+```sh
+turnkey wallets create --name default --key-name default
+```
+
+### Create an Ethereum account
+
+To create a cryptographic key pair on our new Wallet, we neet to pass our desired address format:
+
+```sh
+turnkey wallets accounts create --wallet default --address-format ADDRESS_FORMAT_ETHEREUM --key-name default
+```
+
+This command will produce an Ethereum address (e.g. `0x08cb1216C95149DF66978b574E484869512CE2bF`) that we'll need to sign a transaction. You can see your new Wallet account with:
+
+```sh
+turnkey wallets accounts list --wallet default --key-name default
+```
+
+### Sign a Transaction
+
+Now you can sign an Ethereum transaction with this new address with our [`sign_transaction` endpoint](https://docs.turnkey.com/api-reference/signing/sign-transaction). Make sure to replace the `unsignedTransaction` below with your own. You can use our [simple transaction generator](https://build.tx.xyz/) if you need a quick transaction for testing:
+
+```json
+turnkey request --path /public/v1/submit/sign_transaction --body '{
+    "timestampMs": "'"$(date +%s)"'000",
+    "type": "ACTIVITY_TYPE_SIGN_TRANSACTION_V2",
+    "organizationId": "'"$ORGANIZATION_ID"'",
+    "parameters": {
+      "type": "TRANSACTION_TYPE_ETHEREUM",
+      "signWith": "<Your Ethereum address>",
+      "unsignedTransaction": "<Your Transaction>"
+    }
+}' --key-name default
+```
+
+### Next Steps
+
+See the [official docs](https://docs.turnkey.com/sdks/cli#next-steps) for additional usage information and examples.
+
 ## Building
 
 ### Build for all platforms

--- a/README.md
+++ b/README.md
@@ -241,7 +241,7 @@ turnkey wallets accounts list --wallet default --key-name default
 
 Now you can sign an Ethereum transaction with this new address with our [`sign_transaction` endpoint](https://docs.turnkey.com/api-reference/signing/sign-transaction). Make sure to replace the `unsignedTransaction` below with your own. You can use our [simple transaction generator](https://build.tx.xyz/) if you need a quick transaction for testing:
 
-```json
+```sh
 turnkey request --path /public/v1/submit/sign_transaction --body '{
     "timestampMs": "'"$(date +%s)"'000",
     "type": "ACTIVITY_TYPE_SIGN_TRANSACTION_V2",


### PR DESCRIPTION
## Summary & Motivation (Problem vs. Solution)

As described in #100, there is no explanation in the repository how to "properly" save the API keys without following bytes (including a `\n`ewline character). This brings the instructions up-to-date with what is found at https://docs.turnkey.com/sdks/cli#add-your-public-api-key. These changes also get rid of the outdated `/api/v1/sign` instructions that are no longer pointing to live endpoints.

## Release Steps
See README for additional details.

- [ ] Tag the release (once approved)
- [ ] Attest (once merged)
- [ ] Create release with changelog
- [ ] Update Homebrew tap
