### PR TITLE
fix: flake go version bump for workspaces

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -34,10 +34,27 @@
         "type": "github"
       }
     },
+    "nixpkgs-go": {
+      "locked": {
+        "lastModified": 1720535198,
+        "narHash": "sha256-zwVvxrdIzralnSbcpghA92tWu2DV2lwv89xZc8MTrbg=",
+        "owner": "nixos",
+        "repo": "nixpkgs",
+        "rev": "205fd4226592cc83fd4c0885a3e4c9c400efabb5",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nixos",
+        "ref": "nixos-23.11",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
     "root": {
       "inputs": {
         "flake-utils": "flake-utils",
-        "nixpkgs": "nixpkgs"
+        "nixpkgs": "nixpkgs",
+        "nixpkgs-go": "nixpkgs-go"
       }
     },
     "systems": {

--- a/flake.nix
+++ b/flake.nix
@@ -2,14 +2,18 @@
   description = "tkcli devshell";
   inputs = {
     nixpkgs.url = "github:nixos/nixpkgs/nixos-23.05";
+    nixpkgs-go.url = "github:nixos/nixpkgs/nixos-23.11";
     #nixpkgs.url = "github:NixOS/nixpkgs/nixos-unstable"; # localstack is broken right now (2023-01-25) in unstable, due to a missing dependency
     flake-utils.url = "github:numtide/flake-utils";
   };
 
-  outputs = { self, nixpkgs, flake-utils, ... }@inputs:
+  outputs = { self, nixpkgs, nixpkgs-go, flake-utils, ... }@inputs:
     flake-utils.lib.eachDefaultSystem (system:
       let
         pkgs = nixpkgs.legacyPackages.${system};
+        goPkgs = nixpkgs-go.legacyPackages.${system};
+        go = goPkgs.go_1_21;
+        golangci-lint = goPkgs.golangci-lint;
 
         gci = pkgs.buildGoModule rec {
            name = "gci";
@@ -28,19 +32,19 @@
         tkbuild = pkgs.writeScriptBin "build" ''
           #!/bin/sh
           pushd $(git rev-parse --show-toplevel)/src
-          ${pkgs.go}/bin/go build -o $(go env GOPATH)/bin/turnkey
-          ${pkgs.go}/bin/go build -o ../out/turnkey.linux-x86_64 # hack for local CLI go test
+          ${go}/bin/go build -o $(go env GOPATH)/bin/turnkey ./cmd/turnkey
+          ${go}/bin/go build -o ../out/turnkey.linux-x86_64 ./cmd/turnkey # hack for local CLI go test
         '';
 
         tklint = pkgs.writeScriptBin "lint" ''
           #!/bin/sh
           pushd $(git rev-parse --show-toplevel)/src
-          ${pkgs.go}/bin/go mod tidy
-          ${pkgs.gofumpt}/bin/gofumpt -w *.go ./cmd/*
+          ${go}/bin/go mod tidy
+          ${pkgs.gofumpt}/bin/gofumpt -w ./cmd/*
           ${gci}/bin/gci write --skip-generated -s standard -s default -s "Prefix(github.com/tkhq)" .
-          ${pkgs.golangci-lint}/bin/golangci-lint run ./...
-          ${pkgs.go}/bin/go build -o ../out/turnkey.linux-x86_64 # hack for local CLI go test
-          ${pkgs.go}/bin/go test -v ./...
+          ${golangci-lint}/bin/golangci-lint run ./...
+          ${go}/bin/go build -o ../out/turnkey.linux-x86_64 ./cmd/turnkey # hack for local CLI go test
+          ${go}/bin/go test -v ./...
         '';
       in
       {

--- a/src/go.sum
+++ b/src/go.sum
@@ -189,8 +189,6 @@ github.com/stretchr/testify v1.8.1/go.mod h1:w2LPCIKwWwSfY2zedu0+kehJoqGctiVI29o
 github.com/stretchr/testify v1.8.4 h1:CcVxjf3Q8PM0mHUKJCdn+eZZtm5yQwehR5yeSVQQcUk=
 github.com/stretchr/testify v1.8.4/go.mod h1:sz/lmYIOXD/1dqDmKjjqLyZ2RngseejIcXlSw2iwfAo=
 github.com/tidwall/pretty v1.0.0/go.mod h1:XNkn88O1ChpSDQmQeStsy+sBenx6DDtFZJxhVysOjyk=
-github.com/tkhq/go-sdk v0.0.0-20240813182504-228a50933080 h1:Yhc2J2GCB0SDbLBVwK1ZlrYNiHVuwHGCU+N9CdJz4WQ=
-github.com/tkhq/go-sdk v0.0.0-20240813182504-228a50933080/go.mod h1:NgCPbnpGdhx+31NLwmK3iC6UftT7I70dbKXVbblVpjk=
 github.com/tkhq/go-sdk v0.0.0-20240813203011-ed45fe0d5c27 h1:1Tm6Z2uD9THuycnXtkNbTMf07Owdm071fV5JcKLsAQE=
 github.com/tkhq/go-sdk v0.0.0-20240813203011-ed45fe0d5c27/go.mod h1:2372WQ2x5SWlXmFBygP8PaNcR225Pn8Nd2WmzT9E35Y=
 github.com/tkhq/go-sdk/pkg/enclave_encrypt v0.0.0-20240513225018-5ebfb539ec1e h1:6TQn08QGF615Bt2LRNv1MwlI5qL9NlpO2A/DIKX8MUo=


### PR DESCRIPTION
## Summary & Motivation (Problem vs. Solution)

Running into workspace issues trying to build, and then we needed paths on what to build.

Lot's of ways to do this, I'm unsure how to test the localstack issue or I'd just update everything.

## Release Steps

No release necessary.
