### PR TITLE
chore: update flake go version for builds

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -5,11 +5,11 @@
         "systems": "systems"
       },
       "locked": {
-        "lastModified": 1694529238,
-        "narHash": "sha256-zsNZZGTGnMOf9YpHKJqMSsa0dXbfmxeoJ7xHlrt+xmY=",
+        "lastModified": 1731533236,
+        "narHash": "sha256-l0KFg5HjrsfsO/JpG+r7fRrqm12kzFHyUHqHCVpMMbI=",
         "owner": "numtide",
         "repo": "flake-utils",
-        "rev": "ff7b65b44d01cf9ba6a71320833626af21126384",
+        "rev": "11707dc2f618dd54ca8739b309ec4fc024de578b",
         "type": "github"
       },
       "original": {
@@ -20,16 +20,16 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1697226376,
-        "narHash": "sha256-cumLLb1QOUtWieUnLGqo+ylNt3+fU8Lcv5Zl+tYbRUE=",
+        "lastModified": 1720535198,
+        "narHash": "sha256-zwVvxrdIzralnSbcpghA92tWu2DV2lwv89xZc8MTrbg=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "898cb2064b6e98b8c5499f37e81adbdf2925f7c5",
+        "rev": "205fd4226592cc83fd4c0885a3e4c9c400efabb5",
         "type": "github"
       },
       "original": {
         "owner": "nixos",
-        "ref": "nixos-23.05",
+        "ref": "nixos-23.11",
         "repo": "nixpkgs",
         "type": "github"
       }

--- a/flake.nix
+++ b/flake.nix
@@ -1,8 +1,7 @@
 {
   description = "tkcli devshell";
   inputs = {
-    nixpkgs.url = "github:nixos/nixpkgs/nixos-23.05";
-    #nixpkgs.url = "github:NixOS/nixpkgs/nixos-unstable"; # localstack is broken right now (2023-01-25) in unstable, due to a missing dependency
+    nixpkgs.url = "github:nixos/nixpkgs/nixos-23.11";
     flake-utils.url = "github:numtide/flake-utils";
   };
 
@@ -25,35 +24,37 @@
            vendorSha256 = "sha256-g7htGfU6C2rzfu8hAn6SGr0ZRwB8ZzSf9CgHYmdupE8=";
         };
 
+        go = pkgs.go_1_21;
+
         tkbuild = pkgs.writeScriptBin "build" ''
           #!/bin/sh
           pushd $(git rev-parse --show-toplevel)/src
-          ${pkgs.go}/bin/go build -o $(go env GOPATH)/bin/turnkey
-          ${pkgs.go}/bin/go build -o ../out/turnkey.linux-x86_64 # hack for local CLI go test
+          ${go}/bin/go build -o $(${go}/bin/go env GOPATH)/bin/turnkey ./cmd/turnkey
+          ${go}/bin/go build -o ../out/turnkey.linux-x86_64 ./cmd/turnkey # hack for local CLI go test
         '';
 
         tklint = pkgs.writeScriptBin "lint" ''
           #!/bin/sh
           pushd $(git rev-parse --show-toplevel)/src
-          ${pkgs.go}/bin/go mod tidy
+          ${go}/bin/go mod tidy
           ${pkgs.gofumpt}/bin/gofumpt -w *.go ./cmd/*
           ${gci}/bin/gci write --skip-generated -s standard -s default -s "Prefix(github.com/tkhq)" .
           ${pkgs.golangci-lint}/bin/golangci-lint run ./...
-          ${pkgs.go}/bin/go build -o ../out/turnkey.linux-x86_64 # hack for local CLI go test
-          ${pkgs.go}/bin/go test -v ./...
+          ${go}/bin/go build -o ../out/turnkey.linux-x86_64 ./cmd/turnkey # hack for local CLI go test
+          ${go}/bin/go test -v ./...
         '';
       in
       {
         devShells.default = pkgs.mkShell {
-          packages = with pkgs; [
-            bashInteractive
-            envsubst
+          packages = [
+            pkgs.bashInteractive
+            pkgs.envsubst
             gci
-            gofumpt
-            golangci-lint
+            pkgs.gofumpt
+            pkgs.golangci-lint
             go
-            go-swagger
-            go-tools
+            pkgs.go-swagger
+            pkgs.go-tools
             tkbuild
             tklint
           ];


### PR DESCRIPTION
## Summary & Motivation (Problem vs. Solution)

Trying to use the nix development environment fails because go is v1.20 and doesn't support workspaces.

Updated to match the go.work version.

Also made a small bump to nixpkgs to get this go version.

I see the `localstack is broken right now (2023-01-25) in unstable, due to a missing dependency`, which seems really old.
I'm going to try and stand up a local version to see if it works now.


## Release Steps
No release required
